### PR TITLE
Replace ubuntu with {{ ansible_distribution }}

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,8 +61,8 @@
         types: deb
         components: stable
         architectures: "{{ system_architecture.stdout }}"
-        uris: https://download.docker.com/linux/ubuntu
-        signed_by: https://download.docker.com/linux/ubuntu/gpg
+        uris: https://download.docker.com/linux/{{ ansible_distribution | lower }}
+        signed_by: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
 
     - name: Update apt sources
       ansible.builtin.apt:


### PR DESCRIPTION
Hi there, 

Thanks for creating this role. I wanted to use this on my Debian bookworm machine instead of the many custom task I pulled from the internet somewhere 😄. Seems there is a small fix required to get this to work on Debian machines.

Hope this helps! 